### PR TITLE
Fix visibility for module private methods

### DIFF
--- a/lib/ruphone.rb
+++ b/lib/ruphone.rb
@@ -33,19 +33,21 @@ module Ruphone
     phone
   end
 
-  private
+  class << self
+    private
 
-  def self.prefix(phone)
-    "+7#{phone}"
-  end
+    def prefix(phone)
+      "+7#{phone}"
+    end
 
-  def self.plus(phone)
-    "+#{phone}"
-  end
+    def plus(phone)
+      "+#{phone}"
+    end
 
-  def self.normalize_city_code(city_code)
-    return city_code if city_code.nil?
-    return city_code[1..-1] if city_code.start_with?('+')
-    city_code
+    def normalize_city_code(city_code)
+      return city_code if city_code.nil?
+      return city_code[1..-1] if city_code.start_with?('+')
+      city_code
+    end
   end
 end


### PR DESCRIPTION
actual behavior:
```
> Ruphone.prefix('88005553535')
=> "+788005553535"                               
```

expected:
```
> Ruphone.prefix('88005553535')                       
NoMethodError: private method `prefix' called for Ruphone:Module
```